### PR TITLE
❤️‍🩹FIX: DropdownMenu selection display with getLabel

### DIFF
--- a/src/components/molecules/DropdownMenu.jsx
+++ b/src/components/molecules/DropdownMenu.jsx
@@ -39,9 +39,9 @@ export default function DropdownMenu({ options, defaultValue, onChange, label })
 								className='hover:bg-primary rounded-sm p-1 px-2 hover:text-white cursor-pointer flex items-center'
 							>
 								<span className='w-[20px]'>
-									{option === selectedOption && '✓'}
+									{getLabel(option) === selectedOption && '✓'}
 								</span>
-								{option}
+								{getLabel(option)}
 							</li>
 						))}
 					</ul>


### PR DESCRIPTION
Updated DropdownMenu to compare and display selected options using getLabel(option) instead of the raw option value. This ensures correct selection highlighting and label rendering when options are objects or require custom labels.