### PR TITLE
Fix product loading check & expand loadMore

### DIFF
--- a/src/components/organisms/ProductsOrg.jsx
+++ b/src/components/organisms/ProductsOrg.jsx
@@ -334,7 +334,7 @@ export default function ProductsOrg() {
 								) : (
 									<div className='w-full text-2xl font-semibold p-10 text-center'>
 										{
-											products ? "Cargando Lista de Productos..." : "No hay productos registrados."
+											products.length !== 0 ? "Cargando Lista de Productos..." : "No hay productos registrados."
 										}
 									</div>
 								)
@@ -359,6 +359,7 @@ export default function ProductsOrg() {
 				isActiveModal &&
 				<ModalContainer
 					setIsActiveModal={handleModalClose}
+					isForm={true}
 					modalTitle={confirmDelete ? "Confirmar borrado" : (editMode ? "Editar Producto" : "Agregar Nuevo Producto")}
 					modalDescription={confirmDelete ? `¿Estás seguro que deseas borrar "${confirmDelete?.name}"? Esta acción no se puede deshacer.` : (editMode ? "Modifica los datos y guarda los cambios" : "Rellena el formulario para agregar un nuevo producto")}
 				>

--- a/src/hooks/useLoadMore.jsx
+++ b/src/hooks/useLoadMore.jsx
@@ -2,10 +2,10 @@
 import React, { useState } from 'react'
 
 export default function useLoadMore() {
-	const [visibleItems, setVisibleItems] = useState(20);
+	const [visibleItems, setVisibleItems] = useState(200);
 
 	const loadMore = () => {
-		setVisibleItems((prev) => prev + 10);
+		setVisibleItems((prev) => prev + 100);
 	}
 	
 	return { visibleItems, loadMore };


### PR DESCRIPTION
Use products.length !== 0 to distinguish an empty array from a loading state so the empty-state message shows correctly. Add isForm={true} to ModalContainer to mark the modal as a form. Increase useLoadMore initial visibleItems from 20 to 200 and the increment from +10 to +100 to load items in larger batches.