### PR TITLE
Add 'deshacer apertura' API and UI

### DIFF
--- a/src/app/api/caja/route.jsx
+++ b/src/app/api/caja/route.jsx
@@ -9,7 +9,7 @@ async function ensureCajaTables() {
     USUARIO_APERTURA INT NULL,
     FECHA_APERTURA DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
     MONTO_INICIAL DECIMAL(12,2) NOT NULL DEFAULT 0,
-    ESTADO ENUM('abierta','cerrada') NOT NULL DEFAULT 'abierta',
+    ESTADO ENUM('abierta','cerrada', 'cancelada') NOT NULL DEFAULT 'abierta',
     FECHA_CIERRE DATETIME NULL,
     USUARIO_CIERRE INT NULL,
     MONTO_FINAL DECIMAL(12,2) NULL,
@@ -182,5 +182,83 @@ export async function PUT(request) {
     try { await conn.rollback(); } catch { }
     try { conn.release(); } catch { }
     return Response.json({ error: e.message }, { status: 500 });
+  }
+}
+
+export async function DELETE(req) {
+  const conn = await pool.getConnection();
+
+  try {
+    const body = await req.json();
+
+    const { sesion_id, sucursal_id } = body;
+
+    if (!sesion_id && !sucursal_id) {
+      return Response.json(
+        { error: 'Sesión o sucursal requerida' },
+        { status: 400 }
+      );
+    }
+
+    // Validar que la sesión exista
+    const [[sesion]] = await conn.query(`
+      SELECT *
+      FROM caja_sesion
+      WHERE ID_SESION = ?
+    `, [sesion_id]);
+
+    if (!sesion) {
+      return Response.json(
+        { error: 'Sesión no encontrada' },
+        { status: 404 }
+      );
+    }
+
+    // Validar que siga abierta
+    if (sesion.ESTADO !== 'abierta') {
+      return Response.json(
+        { error: 'La caja ya no está abierta' },
+        { status: 400 }
+      );
+    }
+
+    // Aquí puedes validar ventas reales
+    // usando factura en vez de ventas
+    const [ventas] = await conn.query(`
+      SELECT COUNT(*) AS total
+      FROM factura
+      WHERE ID_SUCURSAL = ?
+      AND DATE(FECHA) >= DATE(?)
+      AND LOWER(TRIM(IFNULL(ESTADO, ''))) = 'confirmado'
+    `, [sesion.ID_SUCURSAL, sesion.FECHA_APERTURA]);
+
+    if (ventas[0].total > 0) {
+      return Response.json(
+        { error: 'No se puede deshacer porque existen ventas.' },
+        { status: 400 }
+      );
+    }
+
+    // Cancelar sesión
+    await conn.query(`
+      UPDATE caja_sesion
+      SET ESTADO = 'cancelada'
+      WHERE ID_SESION = ?
+    `, [sesion_id]);
+
+    return Response.json({
+      success: true
+    });
+
+  } catch (e) {
+    console.error(e);
+
+    return Response.json(
+      { error: e.message },
+      { status: 500 }
+    );
+
+  } finally {
+    conn.release();
   }
 }

--- a/src/components/organisms/CajaOrg.jsx
+++ b/src/components/organisms/CajaOrg.jsx
@@ -14,6 +14,7 @@ export default function CajaOrg() {
 	const [totalVentas, setTotalVentas] = useState({}); // map sucursalId -> total ventas hoy
 	const [esperadoMap, setEsperadoMap] = useState({});
 	const [cajaErrors, setCajaErrors] = useState({}); // sucursalId -> error message
+	const [cajaAlert, setCajaAlert] = useState(null);
 	console.log(sucursales);
 
 	useEffect(() => {
@@ -141,17 +142,95 @@ export default function CajaOrg() {
 		}
 	};
 
+	const handleUndoOpenCaja = async (id) => {
+		try {
+			const sesionId = cajas?.[id]?.sesionId;
+
+			if (!sesionId) return;
+
+			// Validar que no existan ventas
+			const ventas = Number(totalVentas[id] || 0);
+
+			if (ventas > 0) {
+
+				setCajaAlert({
+					type: 'error',
+					message: 'No puedes deshacer la apertura porque ya existen ventas.'
+				});
+
+				return;
+			}
+
+			await CajaService.deshacerApertura({
+				sesion_id: sesionId,
+				sucursal_id: id
+			});
+
+			// Reset local
+			setCajas(prev => ({
+				...prev,
+				[id]: {
+					status: 'Cerrada',
+					montoInicial: 0,
+					horaApertura: null,
+					sesionId: null,
+					montoFinal: 0,
+					montoFinalRaw: ''
+				}
+			}));
+
+			setCerrarCaja(prev => ({
+				...prev,
+				[id]: false
+			}));
+
+			setEsperadoMap(prev => ({
+				...prev,
+				[id]: 0
+			}));
+
+			setDiferenciaMap(prev => ({
+				...prev,
+				[id]: 0
+			}));
+
+		} catch (e) {
+
+			setCajaAlert({
+				type: 'error',
+				message: e.message || 'Error al deshacer apertura.'
+			});
+			setTimeout(() => {
+				setCajaAlert(null);
+			}, 4000);
+			
+			console.error('Deshacer apertura error:', e);
+		}
+	};
+
 	return (
 		<div className='p-6'>
 			<h2 className='md:text-2xl font-semibold'>Configuracion de cajas en sucursales</h2>
 			<span className='text-sm md:text-medium text-dark/50'>Configura el monto de la apertura de caja para cada una de las sucursales.</span>
-			<div className='grid grid-cols-3 gap-4 mt-4'>
-				<div className='col-span-2 flex flex-col gap-4'>
+			<div className='grid md:grid-cols-3 grid-cols-1 gap-4 mt-4'>
+				<div className='md:col-span-2 flex flex-col gap-4'>
 					{sucursales &&
 						sucursales.map((sucursal, index) => {
 							const caja = cajas[sucursal.value];
 							return (
 								<div key={index} className='border border-dark/20 p-4 rounded-lg flex flex-col gap-2'>
+									{
+										cajaAlert && (
+											<div className={`
+												p-3 rounded-lg mb-3 border
+												${cajaAlert.type === 'error'
+													? 'bg-danger/10 border-danger text-danger'
+													: 'bg-success/10 border-success text-success'}
+											`}>
+												{cajaAlert.message}
+											</div>
+										)
+									}
 									<h2 className='md:text-lg font-semibold'>Caja {sucursal.label}</h2>
 									{caja?.status === 'Cerrada' && (
 										<div className='flex gap-2'>
@@ -214,7 +293,7 @@ export default function CajaOrg() {
 															text={'Deshacer Apertura'}
 															className={'danger'}
 															icon={<FiTrash2 />}
-															func={() => handleCloseCaja(sucursal.value, 0)}
+															func={() => handleUndoOpenCaja(sucursal.value)}
 														/>
 													</>
 												) : (

--- a/src/services/CajaService.jsx
+++ b/src/services/CajaService.jsx
@@ -40,3 +40,13 @@ export const cerrarCaja = async ({ sesion_id, sucursal_id, monto_final, observac
   });
   return parse(res);
 };
+
+export const deshacerApertura = async ({ sesion_id, sucursal_id }) => {
+  const res = await fetch(API_URL, {
+    method: 'DELETE',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ sesion_id, sucursal_id })
+  });
+
+  return parse(res);
+};

--- a/src/utils/imprimirVoucher.jsx
+++ b/src/utils/imprimirVoucher.jsx
@@ -57,7 +57,10 @@ export const imprimirVoucher = async (data) => {
 
     console.log("Factura completa:", factura);
 
-    const clienteNombre = factura.cliente?.nombre || "Consumidor Final";
+    const clienteNombre =
+      factura.cliente?.nombre ||
+      (typeof factura.cliente === "string" ? factura.cliente : null) ||
+      "Consumidor Final";
     const sucursalNombre = factura.sucursal?.nombre || "Sucursal N/A";
     const usuarioNombre = factura.usuario?.nombre || "Vendedor N/A";
 
@@ -148,7 +151,10 @@ export const imprimirVoucherCotizacion = async (data) => {
       return;
     }
 
-    const clienteNombre = cotizacion.cliente?.nombre || "Consumidor Final";
+    const clienteNombre =
+      cotizacion.cliente?.nombre ||
+      (typeof cotizacion.cliente === "string" ? cotizacion.cliente : null) ||
+      "Consumidor Final";
     const sucursalNombre =
       cotizacion.sucursal?.name || cotizacion.sucursal?.label || "Sucursal N/A";
     const usuarioNombre =


### PR DESCRIPTION
Introduce a feature to undo (cancel) an opened caja session when no sales exist.

- DB/schema: add 'cancelada' to ESTADO enum for caja_sesion creation.
- API: implement DELETE /api/caja to validate sesion_id/sucursal_id, ensure session exists and is 'abierta', check factura for confirmed sales since FECHA_APERTURA, and set ESTADO = 'cancelada' if allowed. Returns appropriate 400/404/500 errors.
- Service: add CajaService.deshacerApertura to call the DELETE endpoint.
- UI (CajaOrg): add handleUndoOpenCaja to call the service, show transient alerta messages, reset local caja state/maps on success, and wire the "Deshacer Apertura" button to the new handler; also minor layout adjustments and alert rendering.
- Utils: make imprimirVoucher/imprimirVoucherCotizacion more robust when factura/cotizacion.cliente can be a string by using it as fallback before defaulting to "Consumidor Final".

These changes allow safely reverting an opening when there are no confirmed invoices, preventing inconsistent caja state.