### PR TITLE
Add initial cash withdrawal for cajas

### DIFF
--- a/src/app/api/caja/retiro/route.jsx
+++ b/src/app/api/caja/retiro/route.jsx
@@ -1,0 +1,79 @@
+import pool from '@/lib/db';
+import jwt from 'jsonwebtoken';
+
+function getUserFromToken(req) {
+  try {
+    const token = req.cookies?.get?.('token')?.value ?? null;
+    if (!token) return { usuarioId: null };
+    const decoded = jwt.verify(token, process.env.JWT_SECRET);
+    return {
+      usuarioId: decoded?.id || decoded?.sub || decoded?.userId || decoded?.user_id || null,
+      sucursalId: decoded?.ID_SUCURSAL || decoded?.sucursal_id || null,
+    };
+  } catch { return { usuarioId: null, sucursalId: null }; }
+}
+
+async function ensureCajaTables() {
+  await pool.query(`CREATE TABLE IF NOT EXISTS caja_sesion (
+    ID_SESION INT AUTO_INCREMENT PRIMARY KEY,
+    ID_SUCURSAL VARCHAR(10) NOT NULL,
+    USUARIO_APERTURA INT NULL,
+    FECHA_APERTURA DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    MONTO_INICIAL DECIMAL(12,2) NOT NULL DEFAULT 0,
+    ESTADO ENUM('abierta','cerrada', 'cancelada') NOT NULL DEFAULT 'abierta',
+    FECHA_CIERRE DATETIME NULL,
+    USUARIO_CIERRE INT NULL,
+    MONTO_FINAL DECIMAL(12,2) NULL,
+    TOTAL_VENTAS_EQ_C DECIMAL(12,2) NULL,
+    DIFERENCIA DECIMAL(12,2) NULL,
+    MONTO_RETIRADO_INICIAL DECIMAL(12,2) NULL DEFAULT 0,
+    OBSERVACIONES VARCHAR(255) NULL,
+    INDEX idx_caja_suc_estado (ID_SUCURSAL, ESTADO),
+    INDEX idx_caja_fecha (FECHA_APERTURA)
+  ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;`);
+}
+
+// POST /api/caja/retiro  body: { sesion_id?, sucursal_id?, monto_retirado }
+export async function POST(request) {
+  const conn = await pool.getConnection();
+  try {
+    await ensureCajaTables();
+    const body = await request.json().catch(() => ({}));
+    let sesionId = Number(body?.sesion_id || 0);
+    const sucursalId = (body?.sucursal_id || '').toString().trim();
+    const montoRetiradoRaw = body?.monto_retirado;
+    const montoRetirado = Number(montoRetiradoRaw || 0);
+
+    if (!sesionId) {
+      if (!sucursalId) return Response.json({ error: 'sesion_id o sucursal_id requerido' }, { status: 400 });
+      const [row] = await conn.query('SELECT ID_SESION FROM caja_sesion WHERE ID_SUCURSAL = ? AND ESTADO = "abierta" ORDER BY FECHA_APERTURA DESC LIMIT 1', [sucursalId]);
+      if (!row?.length) {
+        conn.release();
+        return Response.json({ error: 'No hay caja abierta para esta sucursal' }, { status: 404 });
+      }
+      sesionId = row[0].ID_SESION;
+    }
+
+    await conn.beginTransaction();
+    const [[sesion]] = await conn.query('SELECT * FROM caja_sesion WHERE ID_SESION = ? FOR UPDATE', [sesionId]);
+    if (!sesion || sesion.ESTADO !== 'abierta') {
+      await conn.rollback();
+      conn.release();
+      return Response.json({ error: 'Sesión inválida o no abierta' }, { status: 400 });
+    }
+
+    // use provided montoRetirado or default to MONTO_INICIAL
+    const finalMontoRetirado = Number(isNaN(montoRetirado) || montoRetirado <= 0 ? sesion.MONTO_INICIAL || 0 : montoRetirado);
+
+    await conn.query('UPDATE caja_sesion SET MONTO_RETIRADO_INICIAL = ? WHERE ID_SESION = ?', [finalMontoRetirado, sesionId]);
+
+    await conn.commit();
+    conn.release();
+
+    return Response.json({ success: true, sesion_id: sesionId, monto_retirado: finalMontoRetirado });
+  } catch (e) {
+    try { await conn.rollback(); } catch { }
+    try { conn.release(); } catch { }
+    return Response.json({ error: e.message }, { status: 500 });
+  }
+}

--- a/src/app/api/caja/route.jsx
+++ b/src/app/api/caja/route.jsx
@@ -23,6 +23,7 @@ async function ensureCajaTables() {
   const requiredColumns = [
     ['TOTAL_VENTAS_EQ_C', 'DECIMAL(12,2) NULL'],
     ['DIFERENCIA', 'DECIMAL(12,2) NULL'],
+    ['MONTO_RETIRADO_INICIAL', 'DECIMAL(12,2) NULL DEFAULT 0'],
   ];
   for (const [columnName, definition] of requiredColumns) {
     const [rows] = await pool.query(
@@ -69,7 +70,7 @@ export async function GET(request) {
         if (sucursalId) sucursalParam = sucursalId;
       } catch {}
       let sql = `SELECT cs.ID_SESION, cs.ID_SUCURSAL, s.NOMBRE_SUCURSAL, cs.FECHA_APERTURA, cs.FECHA_CIERRE,
-                        cs.MONTO_INICIAL, cs.MONTO_FINAL, cs.TOTAL_VENTAS_EQ_C, cs.DIFERENCIA, cs.ESTADO
+                        cs.MONTO_INICIAL, cs.MONTO_FINAL, cs.MONTO_RETIRADO_INICIAL, cs.TOTAL_VENTAS_EQ_C, cs.DIFERENCIA, cs.ESTADO
                  FROM caja_sesion cs
                  LEFT JOIN sucursal s ON s.ID_SUCURSAL = cs.ID_SUCURSAL `;
       if (sucursalParam) { sql += 'WHERE cs.ID_SUCURSAL = ? '; params.push(sucursalParam); }
@@ -186,13 +187,14 @@ export async function PUT(request) {
     }
 
     const montoInicial = Number(sesion.MONTO_INICIAL || 0);
-    const esperado = Number((montoInicial + totalVentasEqC).toFixed(2));
+    const montoRetirado = Number(sesion.MONTO_RETIRADO_INICIAL || 0);
+    const esperado = Number(((montoInicial - montoRetirado) + totalVentasEqC).toFixed(2));
     const diferencia = Number((montoFinal - esperado).toFixed(2));
 
     const { usuarioId } = getUserFromToken(request);
     await conn.query(
-      'UPDATE caja_sesion SET ESTADO = "cerrada", FECHA_CIERRE = ?, USUARIO_CIERRE = ?, MONTO_FINAL = ?, TOTAL_VENTAS_EQ_C = ?, DIFERENCIA = ?, OBSERVACIONES = ? WHERE ID_SESION = ?',
-      [now, usuarioId, montoFinal, totalVentasEqC, diferencia, observaciones, sesionId]
+      'UPDATE caja_sesion SET ESTADO = "cerrada", FECHA_CIERRE = ?, USUARIO_CIERRE = ?, MONTO_FINAL = ?, TOTAL_VENTAS_EQ_C = ?, DIFERENCIA = ?, MONTO_RETIRADO_INICIAL = ?, OBSERVACIONES = ? WHERE ID_SESION = ?',
+      [now, usuarioId, montoFinal, totalVentasEqC, diferencia, montoRetirado, observaciones, sesionId]
     );
 
     await conn.commit();

--- a/src/components/organisms/CajaOrg.jsx
+++ b/src/components/organisms/CajaOrg.jsx
@@ -9,6 +9,7 @@ export default function CajaOrg() {
 	const [sucursales, setSucursales] = useState([]);
 	const [cajas, setCajas] = useState({}); // por sucursal: { status, montoInicial, horaApertura, sesionId }
 	const [cerrarCaja, setCerrarCaja] = useState({}); // flags por sucursal
+	const [retiradoMap, setRetiradoMap] = useState({}); // sucursalId -> monto retirado del inicial
 	const [diferenciaMap, setDiferenciaMap] = useState({});
 	const [historial, setHistorial] = useState([]);
 	const [totalVentas, setTotalVentas] = useState({}); // map sucursalId -> total ventas hoy
@@ -29,13 +30,17 @@ export default function CajaOrg() {
 					const est = await CajaService.getEstado(s.value);
 					const abierta = est?.abierta;
 					if (abierta) {
-								initialState[s.value] = {
-									status: 'Abierta',
-									montoInicial: Number(abierta.MONTO_INICIAL || 0),
-									horaApertura: new Date(abierta.FECHA_APERTURA).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' }),
-									fechaApertura: abierta.FECHA_APERTURA,
-									sesionId: abierta.ID_SESION,
-								};
+							initialState[s.value] = {
+								status: 'Abierta',
+								montoInicial: Number(abierta.MONTO_INICIAL || 0),
+								horaApertura: new Date(abierta.FECHA_APERTURA).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' }),
+								fechaApertura: abierta.FECHA_APERTURA,
+								sesionId: abierta.ID_SESION,
+								montoRetirado: Number(abierta.MONTO_RETIRADO_INICIAL || 0),
+							};
+							if (Number(abierta.MONTO_RETIRADO_INICIAL || 0) > 0) {
+								setRetiradoMap(prev => ({ ...prev, [s.value]: Number(abierta.MONTO_RETIRADO_INICIAL || 0) }));
+							}
 					} else {
 						initialState[s.value] = { status: 'Cerrada', montoInicial: 0, horaApertura: null, sesionId: null };
 					}
@@ -80,13 +85,14 @@ export default function CajaOrg() {
 					}, 0);
 					setTotalVentas(prev => ({ ...prev, [sucId]: Number(totalHoy.toFixed(2)) }));
 					const inicial = Number(cajas?.[sucId]?.montoInicial || 0);
-					setEsperadoMap(prev => ({ ...prev, [sucId]: Number((inicial + totalHoy).toFixed(2)) }));
+					const retirado = Number(retiradoMap[sucId] || 0);
+					setEsperadoMap(prev => ({ ...prev, [sucId]: Number(((inicial - retirado) + totalHoy).toFixed(2)) }));
 				} catch (err) {
 					console.error('Error cargando ventas para cierre de caja:', err);
 				}
 			})();
 		}
-	}, [cerrarCaja]);
+	}, [cerrarCaja, retiradoMap, cajas]);
 
 	// Recalcular diferencias cuando cambia el esperado (ventas cargadas) o montoFinal en cajas
 	useEffect(() => {
@@ -127,6 +133,7 @@ export default function CajaOrg() {
 			await CajaService.cerrarCaja({ sesion_id: sesionId, sucursal_id: id, monto_final: Number(montoFinal || 0) });
 			setCajas(prev => ({ ...prev, [id]: { status: 'Cerrada', montoInicial: 0, horaApertura: null, sesionId: null } }));
 			setCerrarCaja(prev => ({ ...prev, [id]: false }));
+			setRetiradoMap(prev => ({ ...prev, [id]: 0 }));
 			// refrescar historial y aplicar la diferencia calculada localmente para que se muestre inmediatamente
 			const h = await CajaService.getHistorial({ limit: 20 });
 			const rawHist = h?.historial || [];
@@ -184,6 +191,8 @@ export default function CajaOrg() {
 				[id]: false
 			}));
 
+			setRetiradoMap(prev => ({ ...prev, [id]: 0 }));
+
 			setEsperadoMap(prev => ({
 				...prev,
 				[id]: 0
@@ -205,6 +214,29 @@ export default function CajaOrg() {
 			}, 4000);
 			
 			console.error('Deshacer apertura error:', e);
+		}
+	};
+
+	const handleRetirarInicial = async (id) => {
+		try {
+			const sesionId = cajas?.[id]?.sesionId;
+			if (!sesionId) return;
+			const montoInicial = Number(cajas?.[id]?.montoInicial || 0);
+			// llamar servicio
+			const res = await CajaService.retirarMontoInicial({ sesion_id: sesionId, sucursal_id: id, monto_retirado: montoInicial });
+			const montoRet = Number(res?.monto_retirado || montoInicial);
+			// actualizar estados locales: marcar como retirado y ajustar esperado/diferencia
+			setRetiradoMap(prev => ({ ...prev, [id]: montoRet }));
+			setEsperadoMap(prev => ({ ...prev, [id]: Number(((Number(prev[id] || 0) - montoRet)).toFixed(2)) }));
+			// recompute diferencia based on current montoFinal
+			const montoFinal = Number(cajas?.[id]?.montoFinal || 0);
+			const esperado = Number(((Number(esperadoMap[id] || 0) - montoRet))).toFixed(2);
+			setDiferenciaMap(prev => ({ ...prev, [id]: Number((montoFinal - Number(esperado)).toFixed(2)) }));
+			setCajas(prev => ({ ...prev, [id]: { ...prev[id], montoRetirado: montoRet } }));
+		} catch (e) {
+			setCajaAlert({ type: 'error', message: e.message || 'Error al registrar retiro.' });
+			setTimeout(() => setCajaAlert(null), 4000);
+			console.error('Retirar monto inicial error:', e);
 		}
 	};
 
@@ -319,7 +351,18 @@ export default function CajaOrg() {
 															}}
 															/>
 															{cajaErrors[sucursal.value] && <span className='text-danger text-xs'>{cajaErrors[sucursal.value]}</span>}
-														<Input
+															{/* Retiro de monto inicial para auditoría */}
+															{!retiradoMap[sucursal.value] || Number(retiradoMap[sucursal.value] || 0) === 0 ? (
+																<Button
+																	text={'Retirar Monto Inicial'}
+																	className={'danger'}
+																	func={() => handleRetirarInicial(sucursal.value)}
+																/>
+															) : (
+																<div className='text-sm font-semibold text-dark/60'>Monto inicial retirado: C${Number(retiradoMap[sucursal.value]).toFixed(2)}</div>
+															)}
+
+															<Input
 															label={'Total de Ventas (C$)'}
 															placeholder={'0.00'}
 															inputClass={'no icon'}
@@ -419,6 +462,10 @@ export default function CajaOrg() {
 										<div className='flex flex-col'>
 											<span className='font-semibold text-sm text-dark/60'>Monto Inicial</span>
 											<span className='font-semibold'>C${Number(h.MONTO_INICIAL || 0).toFixed(2)}</span>
+										</div>
+										<div className='flex flex-col'>
+											<span className='font-semibold text-sm text-dark'>Monto Retirado</span>
+											<span className='font-semibold text-danger'>C${Number(h.MONTO_RETIRADO_INICIAL || 0).toFixed(2)}</span>
 										</div>
 										<div className='flex flex-col'>
 											<span className='font-semibold text-sm text-dark/60'>Monto Final</span>

--- a/src/services/CajaService.jsx
+++ b/src/services/CajaService.jsx
@@ -50,3 +50,12 @@ export const deshacerApertura = async ({ sesion_id, sucursal_id }) => {
 
   return parse(res);
 };
+
+export const retirarMontoInicial = async ({ sesion_id, sucursal_id, monto_retirado }) => {
+  const res = await fetch(`${API_URL}/retiro`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ sesion_id, sucursal_id, monto_retirado })
+  });
+  return parse(res);
+};


### PR DESCRIPTION
Add support for withdrawing the initial cash amount from a caja session. A new POST API /api/caja/retiro was added to record MONTO_RETIRADO_INICIAL (and it ensures caja_sesion exists). The main caja route was updated to add/ensure the MONTO_RETIRADO_INICIAL column, include it in GET responses and factor it into expected/difference calculations and the closing (PUT) update. Frontend: CajaOrg now tracks retiro state, exposes a "Retirar Monto Inicial" action, updates local expected/difference calculations and displays the withdrawn amount in the history. A new service function retirarMontoInicial was added to call the endpoint.